### PR TITLE
feat: refresh chat styling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+
+# Nested workspace
+cngpt-online/node_modules

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,26 @@
 @tailwind components;
 @tailwind utilities;
 
-:root { color-scheme: dark; }
-html, body { height: 100%; }
-body { @apply text-white antialiased; background: radial-gradient(1200px 600px at 50% -10%, #0b1220 0%, #000 55%) fixed; }
-* { scrollbar-width: thin; }
+:root {
+  color-scheme: dark;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  @apply text-white antialiased;
+  /* Galaxy backdrop */
+  background:
+    radial-gradient(1200px 600px at 50% -10%, rgba(14, 26, 52, 0.85) 0%, rgba(1, 7, 15, 0.95) 60%),
+    radial-gradient(800px 400px at 10% 120%, rgba(20, 40, 80, 0.35) 0%, rgba(0, 0, 0, 0) 60%),
+    radial-gradient(700px 350px at 90% 110%, rgba(0, 80, 160, 0.25) 0%, rgba(0, 0, 0, 0) 60%),
+    #000;
+  background-attachment: fixed;
+}
+
+* {
+  scrollbar-width: thin;
+}

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,0 +1,32 @@
+"use client"
+import { Clock3, Settings } from "lucide-react"
+
+export default function ChatHeader({ onOpenHistory }: { onOpenHistory: () => void }) {
+  return (
+    <header className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-5 py-4">
+      <div className="flex items-center gap-3">
+        <div className="grid size-10 place-items-center rounded-full border border-cardic-primary/60">
+          {/* simple avatar ring */}
+          <div className="size-8 rounded-full bg-cardic-primary/20" />
+        </div>
+        <h1 className="text-lg font-semibold tracking-tight">AI Trading Mentor</h1>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onOpenHistory}
+          className="inline-flex items-center gap-2 rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm"
+          title="Past Topics"
+        >
+          <Clock3 className="size-4" /> History
+        </button>
+        <button
+          className="grid size-9 place-items-center rounded-full border border-white/15 bg-white/5"
+          title="Settings"
+        >
+          <Settings className="size-4" />
+        </button>
+      </div>
+    </header>
+  )
+}

--- a/src/components/ComposerBar.tsx
+++ b/src/components/ComposerBar.tsx
@@ -1,0 +1,52 @@
+"use client"
+import { Paperclip, Mic, Send } from "lucide-react"
+import { useState } from "react"
+
+export default function ComposerBar({ onSend }: { onSend: (text: string) => void }) {
+  const [value, setValue] = useState("")
+
+  function send() {
+    const t = value.trim()
+    if (!t) return
+    onSend(t)
+    setValue("")
+  }
+
+  return (
+    <div className="sticky bottom-2">
+      {/* Dark rounded bar like your mock */}
+      <div className="flex items-center gap-2 rounded-2xl border border-cardic-primary/30 bg-[#061225] px-3 py-2">
+        <button
+          className="grid size-10 place-items-center rounded-full text-cardic-primary/80 hover:bg-white/5"
+          title="Attach"
+        >
+          <Paperclip className="size-5" />
+        </button>
+
+        <button
+          className="grid size-10 place-items-center rounded-full text-cardic-primary/80 hover:bg-white/5"
+          title="Voice"
+        >
+          <Mic className="size-5" />
+        </button>
+
+        {/* White pill input */}
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => (e.key === "Enter" ? send() : null)}
+          placeholder="Type a message..."
+          className="flex-1 rounded-full bg-white px-5 py-3 text-[15px] text-black placeholder:text-black/50 outline-none"
+        />
+
+        <button
+          onClick={send}
+          className="grid size-10 place-items-center rounded-full bg-cardic-primary/20 ring-1 ring-cardic-primary/60 transition hover:scale-105"
+          title="Send"
+        >
+          <Send className="size-5 text-cardic-primary" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,17 +1,21 @@
 import { cn } from "@/lib/utils"
 
-export function MessageBubble({ role, content }: { role: 'user'|'mentor', content: string }) {
-  const isUser = role === 'user'
+export function MessageBubble({ role, content }: { role: "user" | "mentor"; content: string }) {
+  const isUser = role === "user"
+
   return (
-    <div className={cn("flex w-full gap-3", isUser ? 'justify-end' : 'justify-start')}>
-      {!isUser && (<div className="size-9 shrink-0 rounded-full bg-cardic.primary/20 ring-1 ring-cardic.primary/40" />)}
-      <div className={cn(
-        'max-w-[85%] rounded-2xl px-4 py-3 text-sm shadow-glow',
-        isUser ? 'bg-white text-black border border-cardic.gold/40' : 'bg-cardic.primary/10 text-white border border-cardic.primary/30'
-      )}>
-        <p className="leading-relaxed">{content}</p>
+    <div className={cn("flex w-full", isUser ? "justify-end" : "justify-start")}>
+      <div
+        className={cn(
+          "max-w-[85%] rounded-2xl px-5 py-4 text-[15px] leading-relaxed",
+          isUser
+            ? "bg-white text-black shadow"
+            : "bg-[#0B1B36] text-white border border-cardic-primary/80 shadow-glow"
+        )}
+        style={isUser ? { borderRadius: "18px" } : { borderRadius: "18px" }}
+      >
+        {content}
       </div>
-      {isUser && (<div className="size-9 shrink-0 rounded-full bg-cardic.gold/20 ring-1 ring-cardic.gold/40" />)}
     </div>
   )
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,8 +1,23 @@
-import type { Config } from 'tailwindcss'
+import type { Config } from "tailwindcss"
+
 const config: Config = {
   darkMode: ["class"],
-  content: ["./src/pages/**/*.{ts,tsx}","./src/components/**/*.{ts,tsx}","./src/app/**/*.{ts,tsx}"],
-  theme: { extend: { colors: { cardic: { bg:"#020617", primary:"#16B5FF", gold:"#F5C451" } }, boxShadow:{ glow:"0 0 30px rgba(22,181,255,0.25)" } } },
-  plugins: []
+  content: ["./src/pages/**/*.{ts,tsx}", "./src/components/**/*.{ts,tsx}", "./src/app/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        cardic: {
+          bg: "#020617",
+          primary: "#16B5FF", // neon blue
+          gold: "#F5C451", // accent (we'll use sparingly)
+        },
+      },
+      boxShadow: {
+        glow: "0 0 30px rgba(22,181,255,0.25)",
+      },
+    },
+  },
+  plugins: [],
 }
+
 export default config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": ["dom","dom.iterable","esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -13,8 +17,24 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "baseUrl": ".",
-    "paths": { "@/*": ["./src/*"] }
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts","src/**/*"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "src/**/*",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add a galaxy-inspired global background treatment and brand tokens for the Cardic palette
- restyle chat bubbles and introduce polished ChatHeader and ComposerBar components
- wire the new UI pieces into the chat page and add lint configuration generated by Next.js

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cee19808ac8320915f0f3177f902be