### PR TITLE
Add profile naming and auto-title controls

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,13 +3,17 @@ import { useEffect, useState } from "react"
 import ChatHeader from "@/components/ChatHeader"
 import ComposerBar from "@/components/ComposerBar"
 import HistorySheet from "@/components/HistorySheet"
+import SettingsSheet from "@/components/SettingsSheet"
 import { MessageBubble } from "@/components/MessageBubble"
+import { useSettings } from "@/hooks/useSettings"
 import { useTopics } from "@/hooks/useTopics"
 import type { Message } from "@/types/chat"
 
 export default function Page() {
-  const { topics, createTopic, deleteTopic, addMessage, getMessages, seedIfEmpty } = useTopics()
+  const { topics, createTopic, deleteTopic, renameTopic, addMessage, getMessages, seedIfEmpty, clearAll } = useTopics()
+  const { settings } = useSettings()
   const [openHistory, setOpenHistory] = useState(false)
+  const [openSettings, setOpenSettings] = useState(false)
   const [currentTopicId, setCurrentTopicId] = useState<string | null>(null)
   const [messages, setMessages] = useState<Message[]>([])
 
@@ -31,6 +35,14 @@ export default function Page() {
 
   function handleSend(text: string) {
     if (!currentTopicId) return
+
+    if (settings.autoTitle) {
+      const current = topics.find((t) => t.id === currentTopicId)
+      if (current && (/^Getting started$/i.test(current.title) || current.title.length < 3)) {
+        const candidate = text.slice(0, 40).replace(/\s+/g, " ").trim()
+        if (candidate) renameTopic(current.id, candidate)
+      }
+    }
     const m: Message = {
       id: crypto.randomUUID(),
       role: "user",
@@ -47,19 +59,23 @@ export default function Page() {
         role: "mentor",
         type: "text",
         content:
-          `Technical analysis involves analyzing past price and volume to spot patterns and make decisions.\n\n` +
-          `**Steps** — 1) Identify trend 2) Mark key levels 3) Define invalidation.\n` +
+          `Technical analysis involves analyzing past price and volume ...\n\n` +
+          `— ${settings.mentorName}\n` +
           `**Risk note** — Education only.`,
         createdAt: Date.now(),
       }
-      addMessage(currentTopicId, r)
       setMessages((p) => [...p, r])
-    }, 600)
+      addMessage(currentTopicId, r)
+    }, 500)
   }
 
   return (
     <main className="flex min-h-[85dvh] flex-col gap-4">
-      <ChatHeader onOpenHistory={() => setOpenHistory(true)} />
+      <ChatHeader
+        onOpenHistory={() => setOpenHistory(true)}
+        onOpenSettings={() => setOpenSettings(true)}
+        mentorName={settings.mentorName}
+      />
 
       <section className="flex-1 space-y-4 overflow-y-auto rounded-2xl border border-white/10 bg-black/20 p-4">
         {messages.map((m) => (
@@ -80,12 +96,29 @@ export default function Page() {
         }}
         onDeleteTopic={(id) => {
           deleteTopic(id)
-          if (currentTopicId === id) setCurrentTopicId(null)
+          if (currentTopicId === id) {
+            setCurrentTopicId(null)
+            setMessages([])
+          }
         }}
         onCreateTopic={(title) => {
           const nt = createTopic(title)
           setCurrentTopicId(nt.id)
           setOpenHistory(false)
+        }}
+      />
+      <SettingsSheet
+        open={openSettings}
+        onClose={() => setOpenSettings(false)}
+        onClearAll={() => {
+          clearAll()
+          setCurrentTopicId(null)
+          setMessages([])
+          setOpenSettings(false)
+        }}
+        currentTopic={currentTopicId ? topics.find((t) => t.id === currentTopicId) ?? null : null}
+        onRenameTopic={(id, title) => {
+          renameTopic(id, title)
         }}
       />
     </main>

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,7 +1,15 @@
 "use client"
 import { Clock3, Settings } from "lucide-react"
 
-export default function ChatHeader({ onOpenHistory }: { onOpenHistory: () => void }) {
+export default function ChatHeader({
+  onOpenHistory,
+  onOpenSettings,
+  mentorName,
+}: {
+  onOpenHistory: () => void
+  onOpenSettings: () => void
+  mentorName: string
+}) {
   return (
     <header className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-5 py-4">
       <div className="flex items-center gap-3">
@@ -9,7 +17,7 @@ export default function ChatHeader({ onOpenHistory }: { onOpenHistory: () => voi
           {/* simple avatar ring */}
           <div className="size-8 rounded-full bg-cardic-primary/20" />
         </div>
-        <h1 className="text-lg font-semibold tracking-tight">AI Trading Mentor</h1>
+        <h1 className="text-lg font-semibold tracking-tight">{mentorName}</h1>
       </div>
 
       <div className="flex items-center gap-2">
@@ -21,6 +29,7 @@ export default function ChatHeader({ onOpenHistory }: { onOpenHistory: () => voi
           <Clock3 className="size-4" /> History
         </button>
         <button
+          onClick={onOpenSettings}
           className="grid size-9 place-items-center rounded-full border border-white/15 bg-white/5"
           title="Settings"
         >

--- a/src/components/SettingsSheet.tsx
+++ b/src/components/SettingsSheet.tsx
@@ -1,0 +1,138 @@
+'use client'
+import { useSettings } from '@/hooks/useSettings'
+import type { Topic } from '@/types/chat'
+import { useEffect, useState } from 'react'
+
+export default function SettingsSheet({
+  open, onClose, onClearAll, currentTopic, onRenameTopic,
+}: {
+  open: boolean
+  onClose: () => void
+  onClearAll: () => void
+  currentTopic: Topic | null
+  onRenameTopic: (id: string, title: string) => void
+}) {
+  const { settings, setTheme, setFontSize, setResponseStyle, setDisplayName, setMentorName, setAutoTitle } = useSettings()
+  const [titleDraft, setTitleDraft] = useState(currentTopic?.title ?? '')
+
+  useEffect(() => {
+    setTitleDraft(currentTopic?.title ?? '')
+  }, [currentTopic?.id, currentTopic?.title])
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex">
+      <div className="w-full max-w-sm bg-black/70 backdrop-blur p-4 border-r border-white/10">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-white text-lg font-semibold">Settings</h3>
+          <button onClick={onClose} className="text-white/70">Close</button>
+        </div>
+
+        {/* Profile */}
+        <section className="mb-4">
+          <h4 className="text-sm mb-2 text-white/70">Profile</h4>
+          <label className="block text-xs text-white/60 mb-1">Your name</label>
+          <input
+            value={settings.displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="Display name"
+            className="w-full rounded-md bg-white/5 px-3 py-2 text-white placeholder:text-white/40 outline-none mb-2"
+          />
+          <label className="block text-xs text-white/60 mb-1">Mentor name</label>
+          <input
+            value={settings.mentorName}
+            onChange={(e) => setMentorName(e.target.value)}
+            placeholder="Mentor name"
+            className="w-full rounded-md bg-white/5 px-3 py-2 text-white placeholder:text-white/40 outline-none"
+          />
+        </section>
+
+        {/* Session */}
+        <section className="mb-5">
+          <h4 className="text-sm mb-2 text-white/70">Session</h4>
+
+          <div className="mb-2">
+            <label className="block text-xs text-white/60 mb-1">Current session title</label>
+            <div className="flex gap-2">
+              <input
+                value={titleDraft}
+                onChange={(e) => setTitleDraft(e.target.value)}
+                placeholder={currentTopic ? currentTopic.title : 'No session open'}
+                disabled={!currentTopic}
+                className="flex-1 rounded-md bg-white/5 px-3 py-2 text-white placeholder:text-white/40 outline-none disabled:opacity-50"
+              />
+              <button
+                disabled={!currentTopic || titleDraft.trim().length === 0}
+                onClick={() => currentTopic && onRenameTopic(currentTopic.id, titleDraft.trim())}
+                className="rounded-md bg-cardic-primary/20 ring-1 ring-cardic-primary/60 px-3 py-2 text-sm disabled:opacity-50">
+                Save
+              </button>
+            </div>
+          </div>
+
+          <label className="inline-flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={settings.autoTitle}
+              onChange={(e) => setAutoTitle(e.target.checked)}
+            />
+            <span className="text-white/80">Auto-title new sessions from first message</span>
+          </label>
+        </section>
+
+        {/* Theme */}
+        <section className="mb-4">
+          <h4 className="text-sm mb-2 text-white/70">Theme</h4>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setTheme('galaxy')}
+              className={`flex-1 rounded-md px-3 py-2 text-sm ${settings.theme==='galaxy' ? 'bg-cardic-primary/20 ring-1 ring-cardic-primary/60' : 'bg-white/5'}`}>
+              Galaxy (default)
+            </button>
+            <button
+              onClick={() => setTheme('plain')}
+              className={`flex-1 rounded-md px-3 py-2 text-sm ${settings.theme==='plain' ? 'bg-cardic-primary/20 ring-1 ring-cardic-primary/60' : 'bg-white/5'}`}>
+              Plain dark
+            </button>
+          </div>
+        </section>
+
+        {/* Font size */}
+        <section className="mb-4">
+          <h4 className="text-sm mb-2 text-white/70">Font Size</h4>
+          <div className="flex gap-2">
+            <button onClick={() => setFontSize('sm')} className={`flex-1 rounded-md px-3 py-2 text-sm ${settings.fontSize==='sm'?'bg-white/10':'bg-white/5'}`}>Small</button>
+            <button onClick={() => setFontSize('md')} className={`flex-1 rounded-md px-3 py-2 text-sm ${settings.fontSize==='md'?'bg-white/10':'bg-white/5'}`}>Medium</button>
+            <button onClick={() => setFontSize('lg')} className={`flex-1 rounded-md px-3 py-2 text-sm ${settings.fontSize==='lg'?'bg-white/10':'bg-white/5'}`}>Large</button>
+          </div>
+        </section>
+
+        {/* Response style */}
+        <section className="mb-5">
+          <h4 className="text-sm mb-2 text-white/70">Mentor Response Style</h4>
+          <div className="grid grid-cols-3 gap-2">
+            <button onClick={() => setResponseStyle('concise')} className={`rounded-md px-3 py-2 text-sm ${settings.responseStyle==='concise'?'bg-white/10':'bg-white/5'}`}>Concise</button>
+            <button onClick={() => setResponseStyle('normal')}  className={`rounded-md px-3 py-2 text-sm ${settings.responseStyle==='normal' ?'bg-white/10':'bg-white/5'}`}>Normal</button>
+            <button onClick={() => setResponseStyle('detailed')}className={`rounded-md px-3 py-2 text-sm ${settings.responseStyle==='detailed'?'bg-white/10':'bg-white/5'}`}>Detailed</button>
+          </div>
+        </section>
+
+        {/* Danger zone */}
+        <section className="mb-4">
+          <h4 className="text-sm mb-2 text-red-300/80">Danger</h4>
+          <button
+            onClick={() => { if (confirm('Clear all topics and messages?')) onClearAll() }}
+            className="w-full rounded-md bg-red-500/10 text-red-200 px-3 py-2 text-sm hover:bg-red-500/20">
+            Clear all history
+          </button>
+        </section>
+
+        <div className="mt-4 text-xs text-white/50">
+          CN-World Beta v0.1 • Education only. Not financial advice.
+        </div>
+      </div>
+      <div className="flex-1" onClick={onClose} />
+    </div>
+  )
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,0 +1,46 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export type Settings = {
+  theme: 'galaxy' | 'plain'
+  fontSize: 'sm' | 'md' | 'lg'
+  responseStyle: 'concise' | 'normal' | 'detailed'
+  displayName: string         // NEW: user public name
+  mentorName: string          // NEW
+  autoTitle: boolean          // NEW: auto-name sessions from first user message
+}
+
+const KEY = 'cn_settings_v1'
+const DEFAULTS: Settings = {
+  theme: 'galaxy',
+  fontSize: 'md',
+  responseStyle: 'normal',
+  displayName: 'You',
+  mentorName: 'AI Trading Mentor',
+  autoTitle: true,
+}
+
+export function useSettings() {
+  const [settings, setSettings] = useState<Settings>(DEFAULTS)
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(KEY)
+      if (raw) setSettings({ ...DEFAULTS, ...JSON.parse(raw) })
+    } catch {}
+  }, [])
+
+  useEffect(() => {
+    try { localStorage.setItem(KEY, JSON.stringify(settings)) } catch {}
+  }, [settings])
+
+  return {
+    settings,
+    setTheme: (theme: Settings['theme']) => setSettings(s => ({ ...s, theme })),
+    setFontSize: (fontSize: Settings['fontSize']) => setSettings(s => ({ ...s, fontSize })),
+    setResponseStyle: (responseStyle: Settings['responseStyle']) => setSettings(s => ({ ...s, responseStyle })),
+    setDisplayName: (displayName: string) => setSettings(s => ({ ...s, displayName })),
+    setMentorName: (mentorName: string) => setSettings(s => ({ ...s, mentorName })),
+    setAutoTitle: (autoTitle: boolean) => setSettings(s => ({ ...s, autoTitle })),
+  } as const
+}

--- a/src/hooks/useTopics.ts
+++ b/src/hooks/useTopics.ts
@@ -10,9 +10,11 @@ export function useTopics(){
   useEffect(()=>{ try{ localStorage.setItem(STORAGE_KEY,JSON.stringify(topics)); localStorage.setItem(MESSAGES_KEY,JSON.stringify(messagesMap)); }catch{} },[topics,messagesMap])
   const createTopic=useCallback((title:string)=>{ const id=`t_${Math.random().toString(36).slice(2,9)}`; const t={id,title,createdAt:now(),lastAt:now()}; setTopics(p=>[t,...p]); setMessagesMap(p=>({...p,[id]:[]})); return t },[])
   const deleteTopic=useCallback((id:string)=>{ setTopics(p=>p.filter(t=>t.id!==id)); setMessagesMap(p=>{ const c={...p}; delete c[id]; return c }) },[])
+  const renameTopic=useCallback((id:string,title:string)=>{ setTopics(p=>p.map(t=>t.id===id?{...t,title}:t)) },[])
   const addMessage=useCallback((tid:string,m:Message)=>{ setMessagesMap(p=>{ const arr=p[tid]??[]; return {...p,[tid]:[...arr,m]} }); setTopics(p=>p.map(t=>t.id===tid?{...t,lastAt:now()}:t)) },[])
   const getMessages=useCallback((tid:string)=>messagesMap[tid]??[],[messagesMap])
   const listTopics=useMemo(()=>[...topics].sort((a,b)=>b.lastAt-a.lastAt),[topics])
   const seedIfEmpty=useCallback(()=>{ if(topics.length===0){ const id=`t_${Math.random().toString(36).slice(2,9)}`; setTopics([{id,title:'Getting started',createdAt:now(),lastAt:now()}]); setMessagesMap({[id]:[{id:`m_${Math.random().toString(36).slice(2,9)}`,role:'mentor',type:'text',content:'Welcome — ask anything about trading or open History.',createdAt:now()}]}) } },[topics.length])
-  return { topics:listTopics, createTopic, deleteTopic, addMessage, getMessages, seedIfEmpty } as const
+  const clearAll=useCallback(()=>{ setTopics([]); setMessagesMap({}) },[])
+  return { topics:listTopics, createTopic, deleteTopic, renameTopic, addMessage, getMessages, seedIfEmpty, clearAll } as const
 }


### PR DESCRIPTION
## Summary
- add a settings hook that persists mentor and user names plus auto-title preference in local storage
- expand the settings sheet with profile/session controls and sync the session title editor
- wire the chat page and header to use the new settings, add topic rename/clear helpers, and auto-title new conversations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef31efec08320938254a376b55706