### PR TITLE
Add left sidebar and notes sheet

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,8 @@ import { useEffect, useMemo, useState } from "react"
 import { MessageBubble } from "@/components/MessageBubble"
 import HistorySheet from "@/components/HistorySheet"
 import SettingsSheet from "@/components/SettingsSheet"
+import NotesSheet from "@/components/NotesSheet"
+import SidebarLeft from "@/components/SidebarLeft"
 import { useTopics } from "@/hooks/useTopics"
 import { useSettings } from "@/hooks/useSettings"
 import type { Message } from "@/types/chat"
@@ -14,6 +16,7 @@ export default function Page() {
   const { settings } = useSettings()
   const [openHistory, setOpenHistory] = useState(false)
   const [openSettings, setOpenSettings] = useState(false)
+  const [openNotes, setOpenNotes] = useState(false)
   const [currentTopicId, setCurrentTopicId] = useState<string | null>(null)
   const [messages, setMessages] = useState<Message[]>([])
 
@@ -36,17 +39,26 @@ export default function Page() {
   const fontSizePx = useMemo(() => settings.fontSize === 'sm' ? 14 : settings.fontSize === 'lg' ? 17 : 15, [settings.fontSize])
 
   return (
-    <main className="flex min-h-[85dvh] flex-col gap-4">
+    <main className="min-h-[85dvh]">
       <ChatHeader onOpenHistory={() => setOpenHistory(true)} onOpenSettings={() => setOpenSettings(true)} />
 
-      <section
-        className="flex-1 space-y-4 overflow-y-auto rounded-2xl border border-white/10 bg-[#040b16]/60 p-4"
-        style={{ fontSize: `${fontSizePx}px` }}
-      >
-        {messages.map(m => <MessageBubble key={m.id} role={m.role} content={m.content} />)}
-      </section>
+      <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-[11rem_1fr]">
+        <SidebarLeft
+          onOpenNotes={() => setOpenNotes(true)}
+          onHome={() => { /* placeholder as requested */ }}
+          onJoin={() => { /* placeholder as requested */ }}
+        />
 
-      <ComposerBar onSend={handleSend} />
+        <div className="flex flex-col gap-4">
+          <section
+            className="flex-1 space-y-4 overflow-y-auto rounded-2xl border border-white/10 bg-[#040b16]/60 p-4"
+            style={{ fontSize: `${fontSizePx}px` }}
+          >
+            {messages.map(m => <MessageBubble key={m.id} role={m.role} content={m.content} />)}
+          </section>
+          <ComposerBar onSend={handleSend} />
+        </div>
+      </div>
 
       <HistorySheet
         open={openHistory}
@@ -63,7 +75,7 @@ export default function Page() {
         onCreateTopic={(title) => {
           const nt = createTopic(title)
           setCurrentTopicId(nt.id)
-          setMessages([])
+          setMessages(getMessages(nt.id))
           setOpenHistory(false)
         }}
       />
@@ -73,6 +85,8 @@ export default function Page() {
         onClose={() => setOpenSettings(false)}
         onClearAll={() => { clearAll(); setCurrentTopicId(null); setMessages([]); setOpenSettings(false); }}
       />
+
+      <NotesSheet open={openNotes} onClose={() => setOpenNotes(false)} />
     </main>
   )
 }

--- a/src/components/NotesSheet.tsx
+++ b/src/components/NotesSheet.tsx
@@ -1,0 +1,90 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { useNotes } from '@/hooks/useNotes'
+
+export default function NotesSheet({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { topics, activeId, activeTopic, activeContent, setActive, createTopic, renameTopic, deleteTopic, saveContent } = useNotes()
+  const [draft, setDraft] = useState(activeContent)
+  const [titleEdit, setTitleEdit] = useState(activeTopic?.title ?? '')
+
+  useEffect(()=>{ setDraft(activeContent); setTitleEdit(activeTopic?.title ?? '') },[activeId, activeContent, activeTopic?.title])
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex">
+      {/* Left: topics list */}
+      <div className="w-full max-w-xs bg-black/70 backdrop-blur p-4 border-r border-white/10">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-white text-lg font-semibold">Notes</h3>
+          <button onClick={onClose} className="text-white/70">Close</button>
+        </div>
+
+        <button
+          onClick={() => createTopic('New note')}
+          className="w-full mb-3 rounded-md bg-cardic-primary/20 ring-1 ring-cardic-primary/60 px-3 py-2 text-sm">
+          + New note
+        </button>
+
+        <div className="space-y-2 max-h-[55vh] overflow-auto">
+          {topics.map(t=>(
+            <div key={t.id}
+              className={`rounded-md p-3 cursor-pointer ${t.id===activeId ? 'bg-white/10' : 'bg-white/5 hover:bg-white/10'}`}
+              onClick={()=>setActive(t.id)}
+            >
+              <div className="text-sm font-medium text-white truncate">{t.title}</div>
+              <div className="text-[11px] text-white/50">{new Date(t.updatedAt).toLocaleString()}</div>
+            </div>
+          ))}
+          {topics.length===0 && <div className="text-white/60 text-sm">No notes yet.</div>}
+        </div>
+      </div>
+
+      {/* Right: editor */}
+      <div className="flex-1 bg-black/40 backdrop-blur p-4">
+        <div className="max-w-3xl mx-auto space-y-3">
+          {/* Title row */}
+          <div className="flex items-center gap-2">
+            <input
+              value={titleEdit}
+              onChange={e=>setTitleEdit(e.target.value)}
+              placeholder="Note title"
+              disabled={!activeTopic}
+              className="flex-1 rounded-md bg-white/90 px-3 py-2 text-black placeholder:text-black/50 outline-none disabled:opacity-50"
+            />
+            <button
+              onClick={()=> activeTopic && renameTopic(activeTopic.id, titleEdit.trim() || 'Untitled note')}
+              disabled={!activeTopic}
+              className="rounded-md bg-cardic-primary/20 ring-1 ring-cardic-primary/60 px-3 py-2 text-sm disabled:opacity-50">
+              Save title
+            </button>
+            <button
+              onClick={()=> activeTopic && deleteTopic(activeTopic.id)}
+              disabled={!activeTopic}
+              className="rounded-md bg-red-500/10 text-red-200 px-3 py-2 text-sm disabled:opacity-50">
+              Delete
+            </button>
+          </div>
+
+          {/* Editor */}
+          <textarea
+            value={draft}
+            onChange={e=>setDraft(e.target.value)}
+            placeholder="Start writing…"
+            className="w-full h-[55vh] rounded-xl bg-white text-black p-4 leading-relaxed shadow border border-black/10 outline-none"
+          />
+          <div className="flex justify-end gap-2">
+            <button
+              onClick={()=> activeTopic && saveContent(activeTopic.id, draft)}
+              disabled={!activeTopic}
+              className="rounded-md bg-cardic-primary/20 ring-1 ring-cardic-primary/60 px-4 py-2 text-sm disabled:opacity-50">
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1" onClick={onClose}/>
+    </div>
+  )
+}

--- a/src/components/SidebarLeft.tsx
+++ b/src/components/SidebarLeft.tsx
@@ -1,0 +1,18 @@
+'use client'
+export default function SidebarLeft({
+  onOpenNotes, onHome, onJoin,
+}: { onOpenNotes: () => void; onHome: () => void; onJoin: () => void }) {
+  const base =
+    "w-full font-semibold tracking-wide rounded-xl px-4 py-3 border-2 text-left " +
+    "border-cardic-primary/80 hover:bg-cardic-primary/10 transition"
+
+  return (
+    <aside className="hidden md:block sticky top-4 self-start w-44">
+      <div className="flex flex-col gap-3">
+        <button className={base} onClick={onHome}>Home</button>
+        <button className={base} onClick={onOpenNotes}>Notes</button>
+        <button className={base} onClick={onJoin}>Join Club</button>
+      </div>
+    </aside>
+  )
+}

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -1,0 +1,77 @@
+'use client'
+import { useCallback, useEffect, useState } from 'react'
+
+export type NoteTopic = { id: string; title: string; createdAt: number; updatedAt: number }
+export type NotesState = {
+  topics: NoteTopic[]
+  activeId: string | null
+  contentMap: Record<string, string>
+}
+
+const KEY = 'cn_notes_v1'
+
+const seed = (): NotesState => {
+  const id = `n_${Math.random().toString(36).slice(2,9)}`
+  return {
+    topics: [{ id, title: 'My first note', createdAt: Date.now(), updatedAt: Date.now() }],
+    activeId: id,
+    contentMap: { [id]: '' }
+  }
+}
+
+export function useNotes(){
+  const [state, setState] = useState<NotesState>(seed())
+
+  useEffect(()=>{
+    try{
+      const raw = localStorage.getItem(KEY)
+      if(raw){
+        const parsed = JSON.parse(raw) as NotesState
+        if (parsed && parsed.topics?.length) setState(parsed)
+      }
+    }catch{}
+  },[])
+  useEffect(()=>{
+    try{ localStorage.setItem(KEY, JSON.stringify(state)) }catch{}
+  },[state])
+
+  const createTopic = useCallback((title: string) => {
+    const id = `n_${Math.random().toString(36).slice(2,9)}`
+    setState(s => ({
+      topics: [{ id, title: title || 'Untitled note', createdAt: Date.now(), updatedAt: Date.now() }, ...s.topics],
+      activeId: id,
+      contentMap: { ...s.contentMap, [id]: '' }
+    }))
+    return id
+  },[])
+
+  const renameTopic = useCallback((id: string, title: string) => {
+    setState(s => ({
+      ...s,
+      topics: s.topics.map(t => t.id === id ? { ...t, title, updatedAt: Date.now() } : t)
+    }))
+  },[])
+
+  const deleteTopic = useCallback((id: string) => {
+    setState(s => {
+      const topics = s.topics.filter(t => t.id !== id)
+      const { [id]: _, ...rest } = s.contentMap
+      const activeId = s.activeId === id ? (topics[0]?.id ?? null) : s.activeId
+      return { topics, activeId, contentMap: rest }
+    })
+  },[])
+
+  const setActive = useCallback((id: string) => setState(s => ({ ...s, activeId: id })),[])
+  const saveContent = useCallback((id: string, content: string) => {
+    setState(s => ({
+      ...s,
+      contentMap: { ...s.contentMap, [id]: content },
+      topics: s.topics.map(t => t.id === id ? { ...t, updatedAt: Date.now() } : t)
+    }))
+  },[])
+
+  const activeContent = (state.activeId ? state.contentMap[state.activeId] ?? '' : '')
+  const activeTopic = state.topics.find(t => t.id === state.activeId) ?? null
+
+  return { ...state, createTopic, renameTopic, deleteTopic, setActive, saveContent, activeContent, activeTopic } as const
+}


### PR DESCRIPTION
## Summary
- add a notes state hook backed by localStorage for topics and content
- build a notes sheet UI to manage note topics and edit content
- introduce a left sidebar with neon buttons and wire the notes sheet into the home page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cefc15fb308320b7c8c31d8b90b84b