### PR TITLE
Add Play Game action to left sidebar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { useSettings } from "@/hooks/useSettings"
 import type { Message } from "@/types/chat"
 import ChatHeader from "@/components/ChatHeader"
 import ComposerBar from "@/components/ComposerBar"
+import SidebarLeft from "@/components/SidebarLeft"
 
 export default function Page() {
   const { topics, createTopic, deleteTopic, addMessage, getMessages, seedIfEmpty, clearAll } = useTopics()
@@ -36,17 +37,27 @@ export default function Page() {
   const fontSizePx = useMemo(() => settings.fontSize === 'sm' ? 14 : settings.fontSize === 'lg' ? 17 : 15, [settings.fontSize])
 
   return (
-    <main className="flex min-h-[85dvh] flex-col gap-4">
+    <main className="min-h-[85dvh]">
       <ChatHeader onOpenHistory={() => setOpenHistory(true)} onOpenSettings={() => setOpenSettings(true)} />
 
-      <section
-        className="flex-1 space-y-4 overflow-y-auto rounded-2xl border border-white/10 bg-[#040b16]/60 p-4"
-        style={{ fontSize: `${fontSizePx}px` }}
-      >
-        {messages.map(m => <MessageBubble key={m.id} role={m.role} content={m.content} />)}
-      </section>
+      <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-[11rem_1fr]">
+        <SidebarLeft
+          onOpenNotes={() => { /* TODO: route later */ }}
+          onHome={() => { /* TODO: route later */ }}
+          onJoin={() => { /* TODO: route later */ }}
+          onPlayGame={() => { /* TODO: open game later */ }}
+        />
 
-      <ComposerBar onSend={handleSend} />
+        <div className="flex flex-col gap-4">
+          <section
+            className="flex-1 space-y-4 overflow-y-auto rounded-2xl border border-white/10 bg-[#040b16]/60 p-4"
+            style={{ fontSize: `${fontSizePx}px` }}
+          >
+            {messages.map(m => <MessageBubble key={m.id} role={m.role} content={m.content} />)}
+          </section>
+          <ComposerBar onSend={handleSend} />
+        </div>
+      </div>
 
       <HistorySheet
         open={openHistory}

--- a/src/components/SidebarLeft.tsx
+++ b/src/components/SidebarLeft.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+export default function SidebarLeft({
+  onOpenNotes,
+  onHome,
+  onJoin,
+  onPlayGame, // NEW
+}: {
+  onOpenNotes: () => void
+  onHome: () => void
+  onJoin: () => void
+  onPlayGame: () => void // NEW
+}) {
+  const base =
+    "w-full font-semibold tracking-wide rounded-xl px-4 py-3 border-2 text-left " +
+    "border-cardic-primary/80 hover:bg-cardic-primary/10 transition"
+
+  return (
+    <aside className="hidden md:block sticky top-4 self-start w-44">
+      <div className="flex flex-col gap-3">
+        <button className={base} onClick={onHome}>Home</button>
+        <button className={base} onClick={onOpenNotes}>Notes</button>
+        <button className={base} onClick={onJoin}>Join Club</button>
+        <button className={base} onClick={onPlayGame}>Play Game</button> {/* NEW */}
+      </div>
+    </aside>
+  )
+}


### PR DESCRIPTION
## Summary
- add the SidebarLeft component with a fourth Play Game button and new onPlayGame callback
- pass placeholder handlers for SidebarLeft actions from the chat page, keeping chat layout intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf054d1d18832092a4a1ab452b44cb