### PR TITLE
Add chart overlay with TradingView integration

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,8 @@ import { useSettings } from "@/hooks/useSettings"
 import type { Message } from "@/types/chat"
 import ChatHeader from "@/components/ChatHeader"
 import ComposerBar from "@/components/ComposerBar"
+import ChartSheet from "@/components/ChartSheet"
+import { CandlestickChart } from "lucide-react"
 
 export default function Page() {
   const { topics, createTopic, deleteTopic, addMessage, getMessages, seedIfEmpty, clearAll } = useTopics()
@@ -17,6 +19,7 @@ export default function Page() {
   const [openHistory, setOpenHistory] = useState(false)
   const [openSettings, setOpenSettings] = useState(false)
   const [openNotes, setOpenNotes] = useState(false)
+  const [openChart, setOpenChart] = useState(false)
   const [currentTopicId, setCurrentTopicId] = useState<string | null>(null)
   const [messages, setMessages] = useState<Message[]>([])
 
@@ -40,7 +43,11 @@ export default function Page() {
 
   return (
     <main className="min-h-[85dvh]">
-      <ChatHeader onOpenHistory={() => setOpenHistory(true)} onOpenSettings={() => setOpenSettings(true)} />
+      <ChatHeader
+        onOpenHistory={() => setOpenHistory(true)}
+        onOpenSettings={() => setOpenSettings(true)}
+        onOpenChart={() => setOpenChart(true)}
+      />
 
       <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-[11rem_1fr]">
         <SidebarLeft
@@ -87,6 +94,16 @@ export default function Page() {
       />
 
       <NotesSheet open={openNotes} onClose={() => setOpenNotes(false)} />
+      <ChartSheet open={openChart} onClose={() => setOpenChart(false)} symbol="OANDA:XAUUSD" interval="15" />
+
+      <button
+        onClick={() => setOpenChart(true)}
+        className="fixed bottom-24 right-4 grid size-12 place-items-center rounded-full bg-cardic-primary/20 ring-1 ring-cardic-primary/60 shadow-lg md:hidden"
+        title="Open Chart"
+        type="button"
+      >
+        <CandlestickChart className="size-6 text-cardic-primary" />
+      </button>
     </main>
   )
 }

--- a/src/components/ChartSheet.tsx
+++ b/src/components/ChartSheet.tsx
@@ -1,0 +1,43 @@
+"use client"
+import { X } from "lucide-react"
+import TradingViewPanel from "@/components/TradingViewPanel"
+
+type ChartSheetProps = {
+  open: boolean
+  onClose: () => void
+  symbol?: string
+  interval?: string
+}
+
+export default function ChartSheet({
+  open,
+  onClose,
+  symbol = "OANDA:XAUUSD",
+  interval = "15",
+}: ChartSheetProps) {
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+
+      <div className="absolute left-1/2 -translate-x-1/2 bottom-0 md:top-1/2 md:-translate-y-1/2 w-[96%] md:w-[840px]">
+        <div className="overflow-hidden rounded-2xl border border-white/10 bg-[#040b16]/95 shadow-2xl">
+          <div className="flex items-center justify-between border-b border-white/10 p-3">
+            <div className="text-sm text-white/70">Chart</div>
+            <button
+              onClick={onClose}
+              className="grid size-9 place-items-center rounded-md bg-white/5"
+              type="button"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+          <div className="h-[70vh] p-2 md:h-[64vh]">
+            <TradingViewPanel symbol={symbol} interval={interval} />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,9 +1,13 @@
 "use client"
-import { Clock3, Settings } from "lucide-react"
+import { Clock3, Settings, CandlestickChart } from "lucide-react"
 
-export default function ChatHeader({ onOpenHistory, onOpenSettings }:{
-  onOpenHistory: () => void; onOpenSettings: () => void
-}) {
+type ChatHeaderProps = {
+  onOpenHistory: () => void
+  onOpenSettings: () => void
+  onOpenChart: () => void
+}
+
+export default function ChatHeader({ onOpenHistory, onOpenSettings, onOpenChart }: ChatHeaderProps) {
   return (
     <header className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-5 py-4">
       <div className="flex items-center gap-3">
@@ -13,10 +17,18 @@ export default function ChatHeader({ onOpenHistory, onOpenSettings }:{
         <h1 className="text-lg font-semibold tracking-tight">AI Trading Mentor</h1>
       </div>
       <div className="flex items-center gap-2">
+        <button
+          onClick={onOpenChart}
+          className="inline-flex items-center gap-2 rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm"
+          title="Chart"
+          type="button"
+        >
+          <CandlestickChart className="size-4" /> Chart
+        </button>
         <button onClick={onOpenHistory} className="inline-flex items-center gap-2 rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm">
           <Clock3 className="size-4" /> History
         </button>
-        <button onClick={onOpenSettings} className="grid size-9 place-items-center rounded-full border border-white/15 bg-white/5">
+        <button onClick={onOpenSettings} className="grid size-9 place-items-center rounded-full border border-white/15 bg-white/5" title="Settings" type="button">
           <Settings className="size-4" />
         </button>
       </div>

--- a/src/components/TradingViewPanel.tsx
+++ b/src/components/TradingViewPanel.tsx
@@ -1,0 +1,80 @@
+"use client"
+import { useEffect, useRef } from "react"
+
+declare global {
+  interface Window {
+    TradingView?: {
+      widget: (config: Record<string, unknown>) => void
+    }
+  }
+}
+
+const SCRIPT_ID = "tradingview-widget-script"
+const SCRIPT_SRC = "https://s3.tradingview.com/tv.js"
+
+type TradingViewPanelProps = {
+  symbol: string
+  interval: string
+}
+
+export default function TradingViewPanel({ symbol, interval }: TradingViewPanelProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    if (!container.id) {
+      container.id = `tradingview_${Math.random().toString(36).slice(2)}`
+    }
+
+    const initWidget = () => {
+      if (!window.TradingView) return
+      container.innerHTML = ""
+      window.TradingView.widget({
+        autosize: true,
+        symbol,
+        interval,
+        timezone: "Etc/UTC",
+        theme: "dark",
+        style: "1",
+        locale: "en",
+        allow_symbol_change: true,
+        container_id: container.id,
+        withdateranges: true,
+        hide_side_toolbar: false,
+        studies: ["MACD@tv-basicstudies"],
+      })
+    }
+
+    let script = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null
+    let loadHandler: (() => void) | undefined
+
+    if (script && window.TradingView) {
+      initWidget()
+    } else {
+      loadHandler = () => initWidget()
+
+      if (!script) {
+        script = document.createElement("script")
+        script.id = SCRIPT_ID
+        script.src = SCRIPT_SRC
+        script.type = "text/javascript"
+        script.async = true
+        script.addEventListener("load", loadHandler)
+        document.head.appendChild(script)
+      } else {
+        script.addEventListener("load", loadHandler)
+      }
+    }
+
+    return () => {
+      if (loadHandler && script) {
+        script.removeEventListener("load", loadHandler)
+      }
+      container.innerHTML = ""
+    }
+  }, [symbol, interval])
+
+  return <div ref={containerRef} className="size-full" />
+}


### PR DESCRIPTION
## Summary
- add a reusable chart sheet that displays the TradingView advanced chart widget
- introduce a header chart button and floating mobile shortcut to open the overlay
- wire the chart overlay into the main page alongside existing sheets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf186d8b548320a54e25d51bbe3f32