### PR TITLE
Add full chart page with persistent TradingView widget

### DIFF
--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -1,0 +1,63 @@
+"use client"
+import Link from "next/link"
+import TradingViewPanel from "@/components/TradingViewPanel"
+import { useChartPrefs } from "@/hooks/useChartPrefs"
+
+export default function ChartFullPage() {
+  const { prefs, setSymbol, setInterval } = useChartPrefs()
+
+  return (
+    <main className="min-h-[100dvh] px-4 py-4 md:px-6">
+      {/* Top bar */}
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <Link
+          href="/"
+          className="rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm"
+        >
+          ← Return to AI Home
+        </Link>
+
+        {/* Quick controls */}
+        <div className="flex items-center gap-2">
+          <select
+            value={prefs.symbol}
+            onChange={(e)=>setSymbol(e.target.value)}
+            className="rounded-md bg-white/10 px-2 py-1 outline-none text-sm"
+            title="Symbol"
+          >
+            <option value="OANDA:XAUUSD">XAUUSD (Gold)</option>
+            <option value="BINANCE:BTCUSDT">BTCUSDT</option>
+            <option value="OANDA:EURUSD">EURUSD</option>
+            <option value="NASDAQ:QQQ">QQQ</option>
+          </select>
+          <select
+            value={prefs.interval}
+            onChange={(e)=>setInterval(e.target.value)}
+            className="rounded-md bg-white/10 px-2 py-1 outline-none text-sm"
+            title="Interval"
+          >
+            <option value="1">1m</option>
+            <option value="5">5m</option>
+            <option value="15">15m</option>
+            <option value="60">1h</option>
+            <option value="240">4h</option>
+            <option value="D">1D</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Full-screen chart */}
+      <TradingViewPanel symbol={prefs.symbol} interval={prefs.interval} heightClass="h-[calc(100dvh-7.5rem)]" />
+
+      {/* Footer brand (optional) */}
+      <div className="mt-4 text-center">
+        <div className="text-2xl font-extrabold tracking-wide bg-gradient-to-r from-cardic-primary to-cardic-gold bg-clip-text text-transparent">
+          CARDIC NEXUS
+        </div>
+        <div className="text-white/80 text-sm">
+          we dont chase we build from vision to result — welcome to cardic nexus
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,9 +1,10 @@
 "use client"
-import { Clock3, Settings } from "lucide-react"
+import Link from "next/link"
+import { Clock3, Settings, CandlestickChart } from "lucide-react"
 
-export default function ChatHeader({ onOpenHistory, onOpenSettings }:{
-  onOpenHistory: () => void; onOpenSettings: () => void
-}) {
+export default function ChatHeader({
+  onOpenHistory, onOpenSettings,
+}: { onOpenHistory: () => void; onOpenSettings: () => void }) {
   return (
     <header className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-5 py-4">
       <div className="flex items-center gap-3">
@@ -12,11 +13,24 @@ export default function ChatHeader({ onOpenHistory, onOpenSettings }:{
         </div>
         <h1 className="text-lg font-semibold tracking-tight">AI Trading Mentor</h1>
       </div>
+
       <div className="flex items-center gap-2">
-        <button onClick={onOpenHistory} className="inline-flex items-center gap-2 rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm">
+        <Link
+          href="/chart"
+          className="inline-flex items-center gap-2 rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm"
+        >
+          <CandlestickChart className="size-4" /> Chart
+        </Link>
+        <button
+          onClick={onOpenHistory}
+          className="inline-flex items-center gap-2 rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm"
+        >
           <Clock3 className="size-4" /> History
         </button>
-        <button onClick={onOpenSettings} className="grid size-9 place-items-center rounded-full border border-white/15 bg-white/5">
+        <button
+          onClick={onOpenSettings}
+          className="grid size-9 place-items-center rounded-full border border-white/15 bg-white/5"
+        >
           <Settings className="size-4" />
         </button>
       </div>

--- a/src/components/TradingViewPanel.tsx
+++ b/src/components/TradingViewPanel.tsx
@@ -1,0 +1,57 @@
+"use client"
+import { useEffect, useRef } from "react"
+
+export default function TradingViewPanel({
+  symbol = "OANDA:XAUUSD",
+  interval = "15",
+  heightClass = "h-[80vh]", // let page control height
+}: { symbol?: string; interval?: string; heightClass?: string }) {
+  const container = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const target = container.current
+    if (!target) return
+
+    // Clear previous render
+    target.innerHTML = ""
+
+    // Create HTML exactly like TradingView's official snippet
+    const wrap = document.createElement("div")
+    wrap.className = "tradingview-widget-container w-full " + heightClass
+
+    const widget = document.createElement("div")
+    const id = `tv_${Date.now()}_${Math.random().toString(36).slice(2)}`
+    widget.id = id
+    widget.className = "w-full h-full"
+
+    const script = document.createElement("script")
+    script.type = "text/javascript"
+    script.src = "https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js"
+    script.async = true
+    script.innerHTML = JSON.stringify({
+      autosize: true,
+      container_id: id,              // <<< important
+      symbol,
+      interval,
+      theme: "dark",
+      timezone: "Etc/UTC",
+      withdateranges: true,
+      allow_symbol_change: true,
+      hide_legend: false,
+      hide_top_toolbar: false,
+      studies: [],
+      save_image: false,
+      locale: "en",
+    })
+
+    wrap.appendChild(widget)
+    wrap.appendChild(script)
+    target.appendChild(wrap)
+
+    return () => { target.innerHTML = "" }
+  }, [symbol, interval, heightClass])
+
+  return (
+    <div ref={container} className={"rounded-2xl border border-white/10 bg-[#040b16] overflow-hidden " + heightClass}/>
+  )
+}

--- a/src/hooks/useChartPrefs.ts
+++ b/src/hooks/useChartPrefs.ts
@@ -1,0 +1,15 @@
+'use client'
+import { useEffect, useState } from 'react'
+type Prefs = { symbol: string; interval: string }
+const KEY = 'cn_chart_prefs_v1'
+const DEFAULTS: Prefs = { symbol: 'OANDA:XAUUSD', interval: '15' }
+export function useChartPrefs() {
+  const [prefs, setPrefs] = useState<Prefs>(DEFAULTS)
+  useEffect(() => { try { const raw = localStorage.getItem(KEY); if (raw) setPrefs({ ...DEFAULTS, ...JSON.parse(raw) }) } catch {} }, [])
+  useEffect(() => { try { localStorage.setItem(KEY, JSON.stringify(prefs)) } catch {} }, [prefs])
+  return {
+    prefs,
+    setSymbol: (symbol: string) => setPrefs(p => ({ ...p, symbol })),
+    setInterval: (interval: string) => setPrefs(p => ({ ...p, interval })),
+  } as const
+}


### PR DESCRIPTION
## Summary
- add a reusable TradingViewPanel that mirrors the official embed markup for reliable rendering
- persist the selected chart symbol and interval with a new useChartPrefs hook
- introduce a dedicated /chart page with controls and update the header to link to it

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf1da5485c83208296989f43c77da7