### PR TITLE
Add full-screen TradingView chart page

### DIFF
--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -1,0 +1,60 @@
+"use client"
+import Link from "next/link"
+import TradingViewFull from "@/components/TradingViewFull"
+import { useChartPrefs } from "@/hooks/useChartPrefs"
+
+export default function ChartFullPage() {
+  const { prefs, setSymbol, setInterval } = useChartPrefs()
+
+  return (
+    <div className="fixed inset-0 z-0">
+      <TradingViewFull symbol={prefs.symbol} interval={prefs.interval} />
+
+      <div className="absolute left-0 right-0 top-0 z-10 flex items-center justify-between gap-2 p-3">
+        <Link
+          href="/"
+          className="rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm"
+        >
+          ← Return to AI Home
+        </Link>
+
+        <div className="flex items-center gap-2">
+          <select
+            value={prefs.symbol}
+            onChange={(event) => setSymbol(event.target.value)}
+            className="rounded-md border border-white/20 bg-black/60 px-2 py-1 text-sm text-white outline-none"
+            title="Symbol"
+          >
+            <option value="OANDA:XAUUSD">XAUUSD (Gold)</option>
+            <option value="BINANCE:BTCUSDT">BTCUSDT</option>
+            <option value="OANDA:EURUSD">EURUSD</option>
+            <option value="NASDAQ:QQQ">QQQ</option>
+          </select>
+
+          <select
+            value={prefs.interval}
+            onChange={(event) => setInterval(event.target.value)}
+            className="rounded-md border border-white/20 bg-black/60 px-2 py-1 text-sm text-white outline-none"
+            title="Interval"
+          >
+            <option value="1">1m</option>
+            <option value="5">5m</option>
+            <option value="15">15m</option>
+            <option value="60">1h</option>
+            <option value="240">4h</option>
+            <option value="D">1D</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="pointer-events-none absolute bottom-3 left-0 right-0 z-10 text-center">
+        <div className="bg-gradient-to-r from-cardic-primary to-cardic-gold bg-clip-text text-2xl font-extrabold tracking-wide text-transparent md:text-3xl">
+          CARDIC NEXUS
+        </div>
+        <div className="mt-1 text-xs text-white/90 md:text-sm">
+          we dont chase we build from vision to result — welcome to cardic nexus
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TradingViewFull.tsx
+++ b/src/components/TradingViewFull.tsx
@@ -1,0 +1,43 @@
+"use client"
+import { useMemo } from "react"
+
+type Props = {
+  symbol?: string
+  interval?: string
+  theme?: "dark" | "light"
+}
+
+export default function TradingViewFull({
+  symbol = "OANDA:XAUUSD",
+  interval = "15",
+  theme = "dark",
+}: Props) {
+  const src = useMemo(() => {
+    const params = new URLSearchParams({
+      symbol,
+      interval,
+      theme,
+      style: "1",
+      timezone: "Etc/UTC",
+      allow_symbol_change: "1",
+      withdateranges: "1",
+      hide_top_toolbar: "0",
+      hide_legend: "0",
+      save_image: "0",
+      studies: "[]",
+      locale: "en",
+    })
+    return `https://s.tradingview.com/widgetembed/?${params.toString()}`
+  }, [symbol, interval, theme])
+
+  return (
+    <iframe
+      title="TradingView"
+      src={src}
+      className="absolute inset-0 h-full w-full border-0"
+      referrerPolicy="no-referrer"
+      loading="lazy"
+      allow="clipboard-read; clipboard-write; fullscreen; display-capture"
+    />
+  )
+}

--- a/src/hooks/useChartPrefs.ts
+++ b/src/hooks/useChartPrefs.ts
@@ -1,0 +1,64 @@
+"use client"
+import { useCallback, useEffect, useSyncExternalStore } from "react"
+
+type ChartPrefs = {
+  symbol: string
+  interval: string
+}
+
+const KEY = "cn_chart_prefs_v1"
+const DEFAULTS: ChartPrefs = { symbol: "OANDA:XAUUSD", interval: "15" }
+
+let currentPrefs: ChartPrefs = DEFAULTS
+const listeners = new Set<() => void>()
+
+function readFromStorage(): ChartPrefs {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? { ...DEFAULTS, ...JSON.parse(raw) } : DEFAULTS
+  } catch {
+    return DEFAULTS
+  }
+}
+
+function persist(prefs: ChartPrefs) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(prefs))
+  } catch {}
+}
+
+function notify() {
+  listeners.forEach(listener => listener())
+}
+
+function updatePrefs(partial: Partial<ChartPrefs>) {
+  currentPrefs = { ...currentPrefs, ...partial }
+  persist(currentPrefs)
+  notify()
+}
+
+export function useChartPrefs() {
+  const subscribe = useCallback((listener: () => void) => {
+    listeners.add(listener)
+    return () => listeners.delete(listener)
+  }, [])
+
+  const getSnapshot = useCallback(() => currentPrefs, [])
+
+  const prefs = useSyncExternalStore(subscribe, getSnapshot, () => currentPrefs)
+
+  useEffect(() => {
+    const sync = () => {
+      currentPrefs = readFromStorage()
+      notify()
+    }
+    sync()
+    window.addEventListener("storage", sync)
+    return () => window.removeEventListener("storage", sync)
+  }, [])
+
+  const setSymbol = useCallback((symbol: string) => updatePrefs({ symbol }), [])
+  const setInterval = useCallback((interval: string) => updatePrefs({ interval }), [])
+
+  return { prefs, setSymbol, setInterval } as const
+}


### PR DESCRIPTION
## Summary
- add a reusable TradingViewFull iframe component for embedding charts
- implement a full-viewport chart page with overlays for navigation and controls
- persist selected symbol and interval using a new useChartPrefs hook

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf21aa39c8832086da9328d4ddb3e3