### PR TITLE
Restore Play Game button and chart link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,8 +45,9 @@ export default function Page() {
       <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-[11rem_1fr]">
         <SidebarLeft
           onOpenNotes={() => setOpenNotes(true)}
-          onHome={() => { /* placeholder as requested */ }}
-          onJoin={() => { /* placeholder as requested */ }}
+          onHome={() => { /* TODO */ }}
+          onJoin={() => { /* TODO */ }}
+          onPlayGame={() => { /* TODO: open game panel later */ }}
         />
 
         <div className="flex flex-col gap-4">

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,9 +1,19 @@
 "use client"
-import { Clock3, Settings } from "lucide-react"
 
-export default function ChatHeader({ onOpenHistory, onOpenSettings }:{
-  onOpenHistory: () => void; onOpenSettings: () => void
+import Link from "next/link"
+import { CandlestickChart, Clock3, Settings } from "lucide-react"
+
+export default function ChatHeader({
+  onOpenHistory,
+  onOpenSettings,
+}: {
+  onOpenHistory: () => void
+  onOpenSettings: () => void
 }) {
+  const pillButton =
+    "inline-flex items-center gap-2 rounded-full border border-cardic-primary/50 " +
+    "bg-cardic-primary/10 px-3 py-2 text-sm"
+
   return (
     <header className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-5 py-4">
       <div className="flex items-center gap-3">
@@ -12,11 +22,19 @@ export default function ChatHeader({ onOpenHistory, onOpenSettings }:{
         </div>
         <h1 className="text-lg font-semibold tracking-tight">AI Trading Mentor</h1>
       </div>
+
       <div className="flex items-center gap-2">
-        <button onClick={onOpenHistory} className="inline-flex items-center gap-2 rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm">
+        <Link href="/chart" className={pillButton} title="Open Fullscreen Chart">
+          <CandlestickChart className="size-4" /> Chart
+        </Link>
+        <button onClick={onOpenHistory} className={pillButton} title="History">
           <Clock3 className="size-4" /> History
         </button>
-        <button onClick={onOpenSettings} className="grid size-9 place-items-center rounded-full border border-white/15 bg-white/5">
+        <button
+          onClick={onOpenSettings}
+          className="grid size-9 place-items-center rounded-full border border-white/15 bg-white/5"
+          title="Settings"
+        >
           <Settings className="size-4" />
         </button>
       </div>

--- a/src/components/SidebarLeft.tsx
+++ b/src/components/SidebarLeft.tsx
@@ -1,17 +1,37 @@
 'use client'
+
+import { Gamepad2, Home, NotebookPen, Users } from "lucide-react"
+
 export default function SidebarLeft({
-  onOpenNotes, onHome, onJoin,
-}: { onOpenNotes: () => void; onHome: () => void; onJoin: () => void }) {
+  onOpenNotes,
+  onHome,
+  onJoin,
+  onPlayGame,
+}: {
+  onOpenNotes: () => void
+  onHome: () => void
+  onJoin: () => void
+  onPlayGame: () => void
+}) {
   const base =
     "w-full font-semibold tracking-wide rounded-xl px-4 py-3 border-2 text-left " +
-    "border-cardic-primary/80 hover:bg-cardic-primary/10 transition"
+    "border-cardic-primary/80 hover:bg-cardic-primary/10 transition flex items-center gap-2"
 
   return (
-    <aside className="hidden md:block sticky top-4 self-start w-44">
+    <aside className="hidden md:block sticky top-4 self-start w-48">
       <div className="flex flex-col gap-3">
-        <button className={base} onClick={onHome}>Home</button>
-        <button className={base} onClick={onOpenNotes}>Notes</button>
-        <button className={base} onClick={onJoin}>Join Club</button>
+        <button className={base} onClick={onHome}>
+          <Home className="size-4" /> Home
+        </button>
+        <button className={base} onClick={onOpenNotes}>
+          <NotebookPen className="size-4" /> Notes
+        </button>
+        <button className={base} onClick={onJoin}>
+          <Users className="size-4" /> Join Club
+        </button>
+        <button className={base} onClick={onPlayGame}>
+          <Gamepad2 className="size-4" /> Play Game
+        </button>
       </div>
     </aside>
   )


### PR DESCRIPTION
## Summary
- restore the Play Game control in the left sidebar with icon styling consistent with other entries
- reintroduce the Chart navigation pill in the chat header and share button styles across header actions
- wire the page component to pass the Play Game handler so the sidebar compiles cleanly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf2438b2b88320997b449454667bad