### PR TITLE
Add fullscreen chart page with navigation link

### DIFF
--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -1,0 +1,28 @@
+"use client"
+import Link from "next/link"
+
+export default function ChartFullPage() {
+  return (
+    <div className="fixed inset-0 z-0">
+      {/* Fullscreen TradingView (iframe approach = most reliable) */}
+      <iframe
+        title="TradingView"
+        src="https://s.tradingview.com/widgetembed/?symbol=OANDA%3AXAUUSD&interval=15&theme=dark&style=1&timezone=Etc%2FUTC&allow_symbol_change=1&withdateranges=1&hide_top_toolbar=0&hide_legend=0&save_image=0&studies=%5B%5D&locale=en"
+        className="absolute inset-0 w-full h-full border-0"
+        referrerPolicy="no-referrer"
+        loading="lazy"
+        allow="clipboard-read; clipboard-write; fullscreen; display-capture"
+      />
+
+      {/* Overlay controls */}
+      <div className="absolute left-0 right-0 top-0 z-10 flex items-center justify-between gap-2 p-3">
+        <Link
+          href="/"
+          className="rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm"
+        >
+          ← Return to AI Home
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -10,9 +10,6 @@ export default function ChatHeader({
   onOpenHistory: () => void
   onOpenSettings: () => void
 }) {
-  const pillButton =
-    "inline-flex items-center gap-2 rounded-full border border-cardic-primary/50 " +
-    "bg-cardic-primary/10 px-3 py-2 text-sm"
 
   return (
     <header className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-5 py-4">
@@ -24,10 +21,17 @@ export default function ChatHeader({
       </div>
 
       <div className="flex items-center gap-2">
-        <Link href="/chart" className={pillButton} title="Open Fullscreen Chart">
+        <Link
+          href="/chart"
+          className="inline-flex items-center gap-2 rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm"
+          title="Open Fullscreen Chart"
+        >
           <CandlestickChart className="size-4" /> Chart
         </Link>
-        <button onClick={onOpenHistory} className={pillButton} title="History">
+        <button
+          onClick={onOpenHistory}
+          className="inline-flex items-center gap-2 rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm"
+        >
           <Clock3 className="size-4" /> History
         </button>
         <button


### PR DESCRIPTION
## Summary
- add a fullscreen TradingView chart page under `/chart` with an overlay return link
- update the chat header chart button styling and ensure it navigates to the new page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfb29bba8c8320bb262bc922ae01b9