### PR TITLE
Create full-screen TradingView chart page

### DIFF
--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -1,0 +1,65 @@
+"use client"
+import Link from "next/link"
+import TradingViewAdvanced from "@/components/TradingViewAdvanced"
+import { useChartPrefs } from "@/hooks/useChartPrefs"
+
+export default function ChartFullPage() {
+  const { prefs, setSymbol, setInterval } = useChartPrefs()
+
+  return (
+    <div className="fixed inset-0 z-0">
+      {/* Fullscreen advanced chart */}
+      <div className="absolute inset-0">
+        <TradingViewAdvanced symbol={prefs.symbol} interval={prefs.interval} />
+      </div>
+
+      {/* Top controls overlay (non-blocking) */}
+      <div className="pointer-events-none absolute left-0 right-0 top-0 z-10 flex items-center justify-between gap-2 p-3">
+        <Link
+          href="/"
+          className="pointer-events-auto rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm"
+        >
+          ← Return to AI Home
+        </Link>
+
+        <div className="pointer-events-auto flex items-center gap-2">
+          <select
+            value={prefs.symbol}
+            onChange={e => setSymbol(e.target.value)}
+            className="rounded-md bg-black/60 text-white px-2 py-1 outline-none text-sm border border-white/20"
+            title="Symbol"
+          >
+            <option value="OANDA:XAUUSD">XAUUSD (Gold)</option>
+            <option value="BINANCE:BTCUSDT">BTCUSDT</option>
+            <option value="OANDA:EURUSD">EURUSD</option>
+            <option value="NASDAQ:QQQ">QQQ</option>
+          </select>
+
+          <select
+            value={prefs.interval}
+            onChange={e => setInterval(e.target.value)}
+            className="rounded-md bg-black/60 text-white px-2 py-1 outline-none text-sm border border-white/20"
+            title="Interval"
+          >
+            <option value="1">1m</option>
+            <option value="5">5m</option>
+            <option value="15">15m</option>
+            <option value="60">1h</option>
+            <option value="240">4h</option>
+            <option value="D">1D</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Brand footer (non-blocking) */}
+      <div className="pointer-events-none absolute bottom-3 left-0 right-0 z-10 text-center">
+        <div className="text-2xl md:text-3xl font-extrabold tracking-wide bg-gradient-to-r from-cardic-primary to-cardic-gold bg-clip-text text-transparent">
+          CARDIC NEXUS
+        </div>
+        <div className="mt-1 text-xs md:text-sm text-white/90">
+          we dont chase we build from vision to result — welcome to cardic nexus
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TradingViewAdvanced.tsx
+++ b/src/components/TradingViewAdvanced.tsx
@@ -1,0 +1,54 @@
+"use client"
+import { useEffect, useRef } from "react"
+
+export default function TradingViewAdvanced({
+  symbol = "OANDA:XAUUSD",
+  interval = "15",
+}: { symbol?: string; interval?: string }) {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+    host.innerHTML = ""
+
+    const container = document.createElement("div")
+    container.className = "tradingview-widget-container w-full h-full"
+
+    const widget = document.createElement("div")
+    widget.className = "tradingview-widget-container__widget w-full h-full"
+    container.appendChild(widget)
+
+    const script = document.createElement("script")
+    script.type = "text/javascript"
+    script.async = true
+    script.src = "https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js"
+
+    script.innerHTML = JSON.stringify({
+      autosize: true,
+      symbol,
+      interval,
+      timezone: "Etc/UTC",
+      theme: "dark",
+      style: "1",
+      locale: "en",
+      withdateranges: true,
+      range: "12M",
+      allow_symbol_change: true,
+      hide_top_toolbar: false,
+      hide_side_toolbar: false,
+      studies: [],
+      save_image: false,
+      support_host: "https://www.tradingview.com",
+    })
+
+    container.appendChild(script)
+    host.appendChild(container)
+
+    return () => {
+      host.innerHTML = ""
+    }
+  }, [symbol, interval])
+
+  return <div ref={hostRef} className="w-full h-full" />
+}

--- a/src/hooks/useChartPrefs.ts
+++ b/src/hooks/useChartPrefs.ts
@@ -1,0 +1,67 @@
+"use client"
+
+import { useCallback, useEffect, useSyncExternalStore } from "react"
+
+type ChartPrefs = {
+  symbol: string
+  interval: string
+}
+
+const KEY = "cn_chart_prefs_v1"
+const DEFAULTS: ChartPrefs = { symbol: "OANDA:XAUUSD", interval: "15" }
+
+let currentPrefs: ChartPrefs = DEFAULTS
+const listeners = new Set<() => void>()
+
+function readFromStorage(): ChartPrefs {
+  try {
+    const raw = localStorage.getItem(KEY)
+    return raw ? { ...DEFAULTS, ...JSON.parse(raw) } : DEFAULTS
+  } catch {
+    return DEFAULTS
+  }
+}
+
+function persist(prefs: ChartPrefs) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(prefs))
+  } catch {
+    // ignore write errors (e.g., private mode)
+  }
+}
+
+function notify() {
+  listeners.forEach(listener => listener())
+}
+
+function updatePrefs(partial: Partial<ChartPrefs>) {
+  currentPrefs = { ...currentPrefs, ...partial }
+  persist(currentPrefs)
+  notify()
+}
+
+export function useChartPrefs() {
+  const subscribe = useCallback((listener: () => void) => {
+    listeners.add(listener)
+    return () => listeners.delete(listener)
+  }, [])
+
+  const getSnapshot = useCallback(() => currentPrefs, [])
+
+  const prefs = useSyncExternalStore(subscribe, getSnapshot, () => currentPrefs)
+
+  useEffect(() => {
+    const sync = () => {
+      currentPrefs = readFromStorage()
+      notify()
+    }
+    sync()
+    window.addEventListener("storage", sync)
+    return () => window.removeEventListener("storage", sync)
+  }, [])
+
+  const setSymbol = useCallback((symbol: string) => updatePrefs({ symbol }), [])
+  const setInterval = useCallback((interval: string) => updatePrefs({ interval }), [])
+
+  return { prefs, setSymbol, setInterval } as const
+}


### PR DESCRIPTION
## Summary
- add a reusable TradingView advanced chart component that mounts the official widget with toolbar support
- create a full-bleed /chart page overlaying navigation controls that don't block chart interactions
- persist selected chart symbol and interval in local storage with a dedicated chart preferences hook

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfb538af1883208ac6ab0d492a08f8