### PR TITLE
Add fullscreen chart page with floating return link

### DIFF
--- a/src/app/chart/page.tsx
+++ b/src/app/chart/page.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import Link from 'next/link'
+
+import TradingViewAdvanced from '@/components/TradingViewAdvanced'
+import { useChartPrefs } from '@/hooks/useChartPrefs'
+
+export default function ChartFullPage() {
+  const { prefs, setSymbol, setInterval } = useChartPrefs()
+
+  return (
+    <div className="fixed inset-0 z-0">
+      {/* Fullscreen advanced chart */}
+      <div className="absolute inset-0">
+        <TradingViewAdvanced symbol={prefs.symbol} interval={prefs.interval} />
+      </div>
+
+      {/* Left controls (symbol / interval) — top-left, non-blocking */}
+      <div className="pointer-events-none absolute left-0 right-0 top-0 z-10">
+        <div className="pointer-events-auto ml-3 mt-3 flex items-center gap-2">
+          <select
+            value={prefs.symbol}
+            onChange={(e) => setSymbol(e.target.value)}
+            className="rounded-md bg-black/60 text-white px-2 py-1 outline-none text-sm border border-white/20"
+            title="Symbol"
+          >
+            <option value="OANDA:XAUUSD">XAUUSD (Gold)</option>
+            <option value="BINANCE:BTCUSDT">BTCUSDT</option>
+            <option value="OANDA:EURUSD">EURUSD</option>
+            <option value="NASDAQ:QQQ">QQQ</option>
+          </select>
+
+          <select
+            value={prefs.interval}
+            onChange={(e) => setInterval(e.target.value)}
+            className="rounded-md bg-black/60 text-white px-2 py-1 outline-none text-sm border border-white/20"
+            title="Interval"
+          >
+            <option value="1">1m</option>
+            <option value="5">5m</option>
+            <option value="15">15m</option>
+            <option value="60">1h</option>
+            <option value="240">4h</option>
+            <option value="D">1D</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Return button — FLOATING TOP-RIGHT, subtle until hover */}
+      <div className="fixed top-3 right-3 z-20">
+        <Link
+          href="/"
+          className="rounded-full border border-cardic-primary/50 bg-cardic-primary/10 px-3 py-2 text-sm opacity-60 hover:opacity-100 transition pointer-events-auto backdrop-blur"
+          title="Back to AI Mentor"
+        >
+          ← Return to AI Home
+        </Link>
+      </div>
+
+      {/* Brand footer (non-blocking) */}
+      <div className="pointer-events-none absolute bottom-3 left-0 right-0 z-10 text-center">
+        <div className="text-2xl md:text-3xl font-extrabold tracking-wide bg-gradient-to-r from-cardic-primary to-cardic-gold bg-clip-text text-transparent">
+          CARDIC NEXUS
+        </div>
+        <div className="mt-1 text-xs md:text-sm text-white/90">
+          we dont chase we build from vision to result — welcome to cardic nexus
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TradingViewAdvanced.tsx
+++ b/src/components/TradingViewAdvanced.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useId, useMemo } from 'react'
+
+type TradingViewAdvancedProps = {
+  symbol: string
+  interval: string
+}
+
+const BASE_URL = 'https://s.tradingview.com/widgetembed/'
+
+export default function TradingViewAdvanced({ symbol, interval }: TradingViewAdvancedProps) {
+  const rawId = useId()
+  const frameId = useMemo(() => `tradingview_${rawId.replace(/[^a-zA-Z0-9_]/g, '')}`, [rawId])
+
+  const src = useMemo(() => {
+    const params = new URLSearchParams({
+      frameElementId: frameId,
+      symbol,
+      interval,
+      hidesidetoolbar: '0',
+      symboledit: '1',
+      saveimage: '1',
+      toolbarbg: '1f2430',
+      studies: '[]',
+      theme: 'dark',
+      style: '1',
+      timezone: 'Etc/UTC',
+      withdateranges: '1',
+      hideideas: '1',
+      enable_publishing: '0',
+      allow_symbol_change: '1',
+      details: '1',
+      calendar: '1',
+      news: '0',
+      locale: 'en',
+      isTransparent: 'false',
+    })
+
+    return `${BASE_URL}?${params.toString()}`
+  }, [frameId, symbol, interval])
+
+  return (
+    <div className="h-full w-full">
+      <iframe
+        key={src}
+        id={frameId}
+        src={src}
+        className="h-full w-full"
+        frameBorder="0"
+        allow="fullscreen"
+        allowFullScreen
+        allowTransparency
+        title="TradingView advanced chart"
+      />
+    </div>
+  )
+}

--- a/src/hooks/useChartPrefs.ts
+++ b/src/hooks/useChartPrefs.ts
@@ -1,0 +1,73 @@
+'use client'
+
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
+
+type ChartPrefs = {
+  symbol: string
+  interval: string
+}
+
+const STORAGE_KEY = 'cardic_chart_prefs_v1'
+const DEFAULT_PREFS: ChartPrefs = { symbol: 'OANDA:XAUUSD', interval: '60' }
+
+let currentPrefs: ChartPrefs = DEFAULT_PREFS
+const listeners = new Set<() => void>()
+
+function readFromStorage(): ChartPrefs {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return DEFAULT_PREFS
+    const parsed = JSON.parse(raw) as Partial<ChartPrefs>
+    return { ...DEFAULT_PREFS, ...parsed }
+  } catch {
+    return DEFAULT_PREFS
+  }
+}
+
+function persist(prefs: ChartPrefs) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs))
+  } catch {}
+}
+
+function notify() {
+  listeners.forEach(listener => listener())
+}
+
+function update(partial: Partial<ChartPrefs>) {
+  currentPrefs = { ...currentPrefs, ...partial }
+  persist(currentPrefs)
+  notify()
+}
+
+export function useChartPrefs() {
+  const subscribe = useCallback((listener: () => void) => {
+    listeners.add(listener)
+    return () => listeners.delete(listener)
+  }, [])
+
+  const getSnapshot = useCallback(() => currentPrefs, [])
+  const getServerSnapshot = useCallback(() => DEFAULT_PREFS, [])
+
+  useEffect(() => {
+    const sync = () => {
+      currentPrefs = readFromStorage()
+      notify()
+    }
+    sync()
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY) sync()
+    }
+
+    window.addEventListener('storage', handleStorage)
+    return () => window.removeEventListener('storage', handleStorage)
+  }, [])
+
+  const prefs = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+
+  const setSymbol = useCallback((symbol: string) => update({ symbol }), [])
+  const setInterval = useCallback((interval: string) => update({ interval }), [])
+
+  return { prefs, setSymbol, setInterval } as const
+}


### PR DESCRIPTION
## Summary
- add a fullscreen chart route with floating return button and non-blocking overlays
- persist symbol/interval preferences via a new `useChartPrefs` hook
- embed the advanced TradingView chart in a reusable component

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfba7ea27c8320a67a381760f9dc55