### PR TITLE
Add smiling bot logo to chat header

### DIFF
--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -17,10 +17,48 @@ export default function ChatHeader({
   return (
     <header className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-5 py-4">
       <div className="flex items-center gap-3">
-        <div className="grid size-10 place-items-center rounded-full border border-cardic-primary/60">
-          <div className="size-8 rounded-full bg-cardic-primary/20" />
+        <div className="grid size-10 place-items-center rounded-full border border-cardic-primary/60 bg-cardic-primary/10 shadow">
+          {/* Smiling bot logo (inline SVG, neon-blue) */}
+          <svg
+            viewBox="0 0 24 24"
+            className="size-7 text-cardic-primary"
+            aria-hidden="true"
+          >
+            {/* antenna */}
+            <circle cx="12" cy="3" r="1" fill="currentColor" />
+            <path d="M12 4v2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            {/* head */}
+            <rect
+              x="5"
+              y="6.5"
+              width="14"
+              height="11"
+              rx="3.5"
+              ry="3.5"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            />
+            {/* eyes */}
+            <circle cx="9.5" cy="12" r="1.2" fill="currentColor" />
+            <circle cx="14.5" cy="12" r="1.2" fill="currentColor" />
+            {/* smile */}
+            <path
+              d="M9 14.5c.8.8 1.8 1.2 3 1.2s2.2-.4 3-1.2"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+            {/* side-ears */}
+            <rect x="3.5" y="10" width="1.5" height="4" rx="0.75" fill="currentColor" />
+            <rect x="19" y="10" width="1.5" height="4" rx="0.75" fill="currentColor" />
+          </svg>
         </div>
-        <h1 className="text-lg font-semibold tracking-tight">AI Trading Mentor</h1>
+
+        <h1 className="text-lg font-semibold tracking-tight">
+          AI Trading Mentor
+        </h1>
       </div>
 
       <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- replace the blank avatar circle in the chat header with an inline smiling bot SVG icon
- ensure the icon uses the existing neon blue color and maintains the original layout spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfc479097c832097275d56f962ae76