### PR TITLE
Fix settings defaults for mentor configuration

### DIFF
--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -5,10 +5,17 @@ export type Settings = {
   theme: 'galaxy' | 'plain'
   fontSize: 'sm' | 'md' | 'lg'
   responseStyle: 'concise' | 'normal' | 'detailed'
+  mentorName: string
+  persona?: 'coach' | 'analyst' | 'risk'
 }
 
 const KEY = 'cn_settings_v1'
-const DEFAULTS: Settings = { theme: 'galaxy', fontSize: 'md', responseStyle: 'normal' }
+const DEFAULTS: Settings = {
+  theme: 'galaxy',
+  fontSize: 'md',
+  responseStyle: 'normal',
+  mentorName: 'AI Trading Mentor',
+}
 
 let currentSettings: Settings = DEFAULTS
 const listeners = new Set<() => void>()


### PR DESCRIPTION
## Summary
- extend the settings type to include mentor name and persona support
- add a default mentor name so stored settings always provide mentor details

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfe2592f8083209e4050f431b485c7